### PR TITLE
update base url to stop using deprecated endpoint

### DIFF
--- a/lib/hello_fax.rb
+++ b/lib/hello_fax.rb
@@ -6,7 +6,7 @@ module HelloFax
 
     include ::HTTMultiParty
 
-    base_uri "https://www.hellofax.com/apiapp.php/v1/"
+    base_uri "https://api.hellofax.com/v1/"
     headers 'User-Agent' => "hello_fax gem #{VERSION}"
 
     attr_accessor :guid


### PR DESCRIPTION
Latest documentation has all endpoints pointing to api.hellofax.com. See
https://faq.hellosign.com/hc/en-us/articles/216809878-Complete-Walkthrough-for-Setting-Up-The-HelloFax-API

In addition, I've received notive from hellofax that they will deprecate the
old url starting on January 12, 2020.